### PR TITLE
Fix broken links to technical-reviews.md

### DIFF
--- a/_assignments/final-project.md
+++ b/_assignments/final-project.md
@@ -89,7 +89,7 @@ team (both during our face-to-face meeting and after the fact):
 
 _Date: {{site.data.dates.tr1 | date: '%B %d' }}_
 
-**The Architectural review is worth 15% of the project grade ([rubric]({% link _assignments/final-project/technical-reviews.md %})).**
+**The Architectural review is worth 15% of the project grade ([rubric]({% link _assignments/final-project/architectural-review.md %})).**
 
 We will be holding an architectural review which will entail groups of three or four teams taking turns presenting their plans for
 their project. This review is intended to very interactive, and will focus on
@@ -98,7 +98,7 @@ In addition to the in-person component of this activity, there will be a
 framing/agenda setting document due before the review and a
 reflection/synthesis document due after.
 
-See the [Architectural Review]({% link _assignments/final-project/technical-reviews.md %}) page for full details about the assignment.
+See the [Architectural Review]({% link _assignments/final-project/architectural-review.md %}) page for full details about the assignment.
 
 ### Project Presentation
 

--- a/_days/day-23.md
+++ b/_days/day-23.md
@@ -13,5 +13,5 @@ title: Day 23
 
 ## For Next Time
 
-* Thursday: [Technical Review #2]({% link _assignments/final-project/technical-reviews.md %}). Go directly to same room as last time: A+D in AC326; B+E in AC113; C+F in AC126.
+* Thursday: [Technical Review #2]({% link _assignments/final-project/architectural-review.md %}). Go directly to same room as last time: A+D in AC326; B+E in AC113; C+F in AC126.
 * Monday: [Project Presentations]({% link _assignments/final-project/project-presentation-rubric.md %})


### PR DESCRIPTION
Jekyll was throwing errors and wouldn't let me build the site.
The problem seemed to be links to the *_assignments/final-project/technical-reviews.md* page, which was recently renamed to [architectural-review.md](https://github.com/sd17spring/sd17spring.github.io/blob/master/_assignments/final-project/architectural-review.md)
I changed the links to refer to the new page title, and it built successfully for me.
No actual text was changed, only the links - so some of the pages still talk about technical reviews. I figured you'll be making new edits anyways and have a better idea of what needs to be changed.