### PR TITLE
Fix template code for web app toolbox

### DIFF
--- a/_toolboxes/web-apps.md
+++ b/_toolboxes/web-apps.md
@@ -156,15 +156,17 @@ def hello(name=None):
 
 And here is an example template that will work with the above snippet:
 
+{% raw %}
 ``` html
 <!doctype html>
 <title>Hello from Flask</title>
- if name
+{% if name %}
     <h1>Hello {{ name }}!</h1>
- else
+{% else %}
     <h1>Hello World!</h1>
- endif
+{% endif %}
 ```
+{% endraw %}
 
 You may have noticed something really cool that happened here. In our route
 `/hello/<name>`, we're allowing someone to make a request with an additional


### PR DESCRIPTION
@otalu and I were going through the web app toolbox but found that the sample code was incorrect - it was missing a couple tags and wasn't displaying others correctly. It seems that this is related to Jekyll parsing the inline code example instead of ignoring it.
I added the tags and escaped the code block, and it generated correctly on my local machine (see the images below).
It's worth noting that the fixes won't be visible until the build errors are fixed - I fixed those in #12 but figured you might have your own solution ready or want to accept these changes but not those.

**Edit:** I took a gander at the previous website for the course and it matches my updated code

### *example code [from 2016](https://sites.google.com/site/sd16spring/home/project-toolbox/web-apps):*
![capture_previous](https://cloud.githubusercontent.com/assets/10699964/23827364/08debb8e-0680-11e7-8b45-a2481e972730.JPG)

### *current example code:*
![capture_original](https://cloud.githubusercontent.com/assets/10699964/23826882/cfcb123a-0674-11e7-8e8f-3c6f00b14f5f.JPG)

### *fixed example code:*
![capture_fixed](https://cloud.githubusercontent.com/assets/10699964/23826883/cfcb4728-0674-11e7-9d58-26bdf57391be.JPG)



